### PR TITLE
[v3.0.0] Update builder method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ This changelog is initialized in release 1.0.0
 
 ## [Unreleased]
 
+## [v3.0.0] - 2023-03-30
+
+### Changed
+* Update builder method
+
 ## [v2.8.0] - 2023-03-29
 
 ### Added
@@ -67,7 +72,8 @@ This changelog is initialized in release 1.0.0
 * Columns argument to ModelRepositoryInterface::all to be compatible with the underlying Eloquent model
 * FQN options for contract and repository to ModelRepositoryMakeCommand
 
-[Unreleased]: https://github.com/wimski/laravel-model-repositories/compare/v2.8.0...master
+[Unreleased]: https://github.com/wimski/laravel-model-repositories/compare/v3.0.0...master
+[v3.0.0]: https://github.com/wimski/laravel-model-repositories/compare/v2.8.0...v3.0.0
 [v2.8.0]: https://github.com/wimski/laravel-model-repositories/compare/v2.7.0...v2.8.0
 [v2.7.0]: https://github.com/wimski/laravel-model-repositories/compare/v2.6.0...v2.7.0
 [v2.6.0]: https://github.com/wimski/laravel-model-repositories/compare/v2.5.0...v2.6.0

--- a/src/Contracts/Repositories/ModelRepositoryInterface.php
+++ b/src/Contracts/Repositories/ModelRepositoryInterface.php
@@ -8,31 +8,32 @@ use Closure;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Support\LazyCollection;
 
 /**
- * @template T of \Illuminate\Database\Eloquent\Model
+ * @template TModel of Model
  */
 interface ModelRepositoryInterface
 {
     /**
-     * @return Builder<T>|T
+     * @return Builder<TModel>|TModel
      */
     public function builder(bool $withGlobalScopes = true);
 
     /**
      * @param int|string $key
      * @param string     ...$column
-     * @return T|null
+     * @return TModel|null
      */
     public function find($key, string ...$column);
 
     /**
      * @param int|string $key
      * @param string     ...$column
-     * @return T
+     * @return TModel
      * @throws ModelNotFoundException
      */
     public function findOrFail($key, string ...$column);
@@ -40,19 +41,19 @@ interface ModelRepositoryInterface
     /**
      * @param int[]|string[]|Arrayable<int|string, mixed> $keys
      * @param string                                      ...$column
-     * @return Collection<int, T>
+     * @return Collection<int, TModel>
      */
     public function findMany($keys, string ...$column): Collection;
 
     /**
      * @param string ...$column
-     * @return T|null
+     * @return TModel|null
      */
     public function first(string ...$column);
 
     /**
      * @param string ...$column
-     * @return T
+     * @return TModel
      * @throws ModelNotFoundException
      */
     public function firstOrFail(string ...$column);
@@ -62,7 +63,7 @@ interface ModelRepositoryInterface
      * @param mixed                             $operator
      * @param mixed                             $value
      * @param string                            $boolean
-     * @return T|null
+     * @return TModel|null
      */
     public function firstWhere($column, $operator = null, $value = null, string $boolean = 'and');
 
@@ -71,7 +72,7 @@ interface ModelRepositoryInterface
      * @param mixed                             $operator
      * @param mixed                             $value
      * @param string                            $boolean
-     * @return T
+     * @return TModel
      * @throws ModelNotFoundException
      */
     public function firstWhereOrFail($column, $operator = null, $value = null, string $boolean = 'and');
@@ -81,66 +82,66 @@ interface ModelRepositoryInterface
      * @param mixed                             $operator
      * @param mixed                             $value
      * @param string                            $boolean
-     * @return Collection<int, T>
+     * @return Collection<int, TModel>
      */
     public function where($column, $operator = null, $value = null, string $boolean = 'and'): Collection;
 
     /**
      * @param string  $column
      * @param mixed[] $values
-     * @return Collection<int, T>
+     * @return Collection<int, TModel>
      */
     public function whereIn(string $column, array $values): Collection;
 
     /**
      * @param string  $column
      * @param mixed[] $values
-     * @return Collection<int, T>
+     * @return Collection<int, TModel>
      */
     public function whereNotIn(string $column, array $values): Collection;
 
     /**
-     * @return LazyCollection<int, T>
+     * @return LazyCollection<int, TModel>
      */
     public function cursor(): LazyCollection;
 
     /**
      *
      * @param string ...$column
-     * @return Collection<int, T>
+     * @return Collection<int, TModel>
      */
     public function all(string ...$column): Collection;
 
     /**
      * @param array<string, mixed> $attributes
-     * @return T
+     * @return TModel
      */
     public function make(array $attributes);
 
     /**
      * @param int|string $key
      * @param string     ...$column
-     * @return T
+     * @return TModel
      */
     public function findOrMake($key, string ...$column);
 
     /**
      * @param array<string, mixed> $attributes
      * @param array<string, mixed> $values
-     * @return T
+     * @return TModel
      */
     public function firstWhereOrMake(array $attributes, array $values = []);
 
     /**
      * @param array<string, mixed> $attributes
-     * @return T
+     * @return TModel
      */
     public function create(array $attributes);
 
     /**
      * @param array<string, mixed> $attributes
      * @param array<string, mixed> $values
-     * @return T
+     * @return TModel
      */
     public function firstWhereOrCreate(array $attributes, array $values = []);
 }

--- a/src/Contracts/Repositories/ModelRepositoryInterface.php
+++ b/src/Contracts/Repositories/ModelRepositoryInterface.php
@@ -18,9 +18,9 @@ use Illuminate\Support\LazyCollection;
 interface ModelRepositoryInterface
 {
     /**
-     * @return Builder<T>
+     * @return Builder<T>|T
      */
-    public function builder(): Builder;
+    public function builder(bool $withGlobalScopes = true);
 
     /**
      * @param int|string $key

--- a/src/Repositories/AbstractModelRepository.php
+++ b/src/Repositories/AbstractModelRepository.php
@@ -21,11 +21,16 @@ abstract class AbstractModelRepository implements ModelRepositoryInterface
      */
     protected $model;
 
-    public function builder(): Builder
+    public function builder(bool $withGlobalScopes = true)
     {
         /** @var Builder<T> $builder */
-        $builder = $this->model->newQuery();
+        $builder = $this->model->newQueryWithoutScopes();
 
+        if ($withGlobalScopes) {
+            $this->model->registerGlobalScopes($builder);
+        }
+
+        /** @var Builder<T>|T $builder */
         return $builder;
     }
 

--- a/src/Repositories/AbstractModelRepository.php
+++ b/src/Repositories/AbstractModelRepository.php
@@ -37,7 +37,7 @@ abstract class AbstractModelRepository implements ModelRepositoryInterface
     public function find($key, string ...$column)
     {
         /** @var T|null $model */
-        $model = $this->model->find($key, $this->parseColumns(...$column));
+        $model = $this->builder()->find($key, $this->parseColumns(...$column));
 
         return $model;
     }
@@ -45,7 +45,7 @@ abstract class AbstractModelRepository implements ModelRepositoryInterface
     public function findOrFail($key, string ...$column)
     {
         /** @var T $model */
-        $model = $this->model->findOrFail($key, $this->parseColumns(...$column));
+        $model = $this->builder()->findOrFail($key, $this->parseColumns(...$column));
 
         return $model;
     }
@@ -53,7 +53,7 @@ abstract class AbstractModelRepository implements ModelRepositoryInterface
     public function findMany($keys, string ...$column): Collection
     {
         /** @var Collection<int, T> $models */
-        $models = $this->model->findMany($keys, $this->parseColumns(...$column));
+        $models = $this->builder()->findMany($keys, $this->parseColumns(...$column));
 
         return $models;
     }
@@ -61,7 +61,7 @@ abstract class AbstractModelRepository implements ModelRepositoryInterface
     public function first(string ...$column)
     {
         /** @var T|null $model */
-        $model = $this->model->first($this->parseColumns(...$column));
+        $model = $this->builder()->first($this->parseColumns(...$column));
 
         return $model;
     }
@@ -69,7 +69,7 @@ abstract class AbstractModelRepository implements ModelRepositoryInterface
     public function firstOrFail(string ...$column)
     {
         /** @var T $model */
-        $model = $this->model->firstOrFail($this->parseColumns(...$column));
+        $model = $this->builder()->firstOrFail($this->parseColumns(...$column));
 
         return $model;
     }
@@ -77,7 +77,7 @@ abstract class AbstractModelRepository implements ModelRepositoryInterface
     public function firstWhere($column, $operator = null, $value = null, string $boolean = 'and')
     {
         /** @var T|null $model */
-        $model = $this->model->firstWhere($column, $operator, $value, $boolean);
+        $model = $this->builder()->firstWhere($column, $operator, $value, $boolean);
 
         return $model;
     }
@@ -97,7 +97,7 @@ abstract class AbstractModelRepository implements ModelRepositoryInterface
     public function where($column, $operator = null, $value = null, string $boolean = 'and'): Collection
     {
         /** @var Collection<int, T> $models */
-        $models = $this->model->where($column, $operator, $value, $boolean)->get();
+        $models = $this->builder()->where($column, $operator, $value, $boolean)->get();
 
         return $models;
     }
@@ -105,7 +105,7 @@ abstract class AbstractModelRepository implements ModelRepositoryInterface
     public function whereIn(string $column, array $values): Collection
     {
         /** @var Collection<int, T> $models */
-        $models = $this->model->whereIn($column, $values)->get();
+        $models = $this->builder()->whereIn($column, $values)->get();
 
         return $models;
     }
@@ -118,7 +118,7 @@ abstract class AbstractModelRepository implements ModelRepositoryInterface
     public function whereNotIn(string $column, array $values): Collection
     {
         /** @var Collection<int, T> $models */
-        $models = $this->model->whereNotIn($column, $values)->get();
+        $models = $this->builder()->whereNotIn($column, $values)->get();
 
         return $models;
     }
@@ -126,7 +126,7 @@ abstract class AbstractModelRepository implements ModelRepositoryInterface
     public function cursor(): LazyCollection
     {
         /** @var LazyCollection<int, T> $models */
-        $models = $this->model->cursor();
+        $models = $this->builder()->cursor();
 
         return $models;
     }
@@ -134,7 +134,7 @@ abstract class AbstractModelRepository implements ModelRepositoryInterface
     public function all(string ...$column): Collection
     {
         /** @var Collection<int, T> $models */
-        $models = $this->model->all($this->parseColumns(...$column));
+        $models = $this->builder()->get($this->parseColumns(...$column));
 
         return $models;
     }
@@ -142,7 +142,7 @@ abstract class AbstractModelRepository implements ModelRepositoryInterface
     public function make(array $attributes)
     {
         /** @var T $model */
-        $model = $this->model->make($attributes);
+        $model = $this->builder()->make($attributes);
 
         return $model;
     }
@@ -150,7 +150,7 @@ abstract class AbstractModelRepository implements ModelRepositoryInterface
     public function findOrMake($key, string ...$column)
     {
         /** @var T $model */
-        $model = $this->model->findOrNew($key, $this->parseColumns(...$column));
+        $model = $this->builder()->findOrNew($key, $this->parseColumns(...$column));
 
         return $model;
     }
@@ -158,7 +158,7 @@ abstract class AbstractModelRepository implements ModelRepositoryInterface
     public function firstWhereOrMake(array $attributes, array $values = [])
     {
         /** @var T $model */
-        $model = $this->model->firstOrNew($attributes, $values);
+        $model = $this->builder()->firstOrNew($attributes, $values);
 
         return $model;
     }
@@ -166,7 +166,7 @@ abstract class AbstractModelRepository implements ModelRepositoryInterface
     public function create(array $attributes)
     {
         /** @var T $model */
-        $model = $this->model->create($attributes);
+        $model = $this->builder()->create($attributes);
 
         return $model;
     }
@@ -174,7 +174,7 @@ abstract class AbstractModelRepository implements ModelRepositoryInterface
     public function firstWhereOrCreate(array $attributes, array $values = [])
     {
         /** @var T $model */
-        $model = $this->model->firstOrCreate($attributes, $values);
+        $model = $this->builder()->firstOrCreate($attributes, $values);
 
         return $model;
     }

--- a/src/Repositories/AbstractModelRepository.php
+++ b/src/Repositories/AbstractModelRepository.php
@@ -6,37 +6,38 @@ namespace Wimski\ModelRepositories\Repositories;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\LazyCollection;
 use Wimski\ModelRepositories\Contracts\Repositories\ModelRepositoryInterface;
 
 /**
- * @template T of \Illuminate\Database\Eloquent\Model
- * @implements ModelRepositoryInterface<T>
+ * @template TModel of Model
+ * @implements ModelRepositoryInterface<TModel>
  */
 abstract class AbstractModelRepository implements ModelRepositoryInterface
 {
     /**
-     * @var T
+     * @var TModel
      */
-    protected $model;
+    protected Model $model;
 
     public function builder(bool $withGlobalScopes = true)
     {
-        /** @var Builder<T> $builder */
+        /** @var Builder<TModel> $builder */
         $builder = $this->model->newQueryWithoutScopes();
 
         if ($withGlobalScopes) {
             $this->model->registerGlobalScopes($builder);
         }
 
-        /** @var Builder<T>|T $builder */
+        /** @var Builder<TModel>|TModel $builder */
         return $builder;
     }
 
     public function find($key, string ...$column)
     {
-        /** @var T|null $model */
+        /** @var TModel|null $model */
         $model = $this->builder()->find($key, $this->parseColumns(...$column));
 
         return $model;
@@ -44,7 +45,7 @@ abstract class AbstractModelRepository implements ModelRepositoryInterface
 
     public function findOrFail($key, string ...$column)
     {
-        /** @var T $model */
+        /** @var TModel $model */
         $model = $this->builder()->findOrFail($key, $this->parseColumns(...$column));
 
         return $model;
@@ -52,7 +53,7 @@ abstract class AbstractModelRepository implements ModelRepositoryInterface
 
     public function findMany($keys, string ...$column): Collection
     {
-        /** @var Collection<int, T> $models */
+        /** @var Collection<int, TModel> $models */
         $models = $this->builder()->findMany($keys, $this->parseColumns(...$column));
 
         return $models;
@@ -60,7 +61,7 @@ abstract class AbstractModelRepository implements ModelRepositoryInterface
 
     public function first(string ...$column)
     {
-        /** @var T|null $model */
+        /** @var TModel|null $model */
         $model = $this->builder()->first($this->parseColumns(...$column));
 
         return $model;
@@ -68,7 +69,7 @@ abstract class AbstractModelRepository implements ModelRepositoryInterface
 
     public function firstOrFail(string ...$column)
     {
-        /** @var T $model */
+        /** @var TModel $model */
         $model = $this->builder()->firstOrFail($this->parseColumns(...$column));
 
         return $model;
@@ -76,7 +77,7 @@ abstract class AbstractModelRepository implements ModelRepositoryInterface
 
     public function firstWhere($column, $operator = null, $value = null, string $boolean = 'and')
     {
-        /** @var T|null $model */
+        /** @var TModel|null $model */
         $model = $this->builder()->firstWhere($column, $operator, $value, $boolean);
 
         return $model;
@@ -90,13 +91,13 @@ abstract class AbstractModelRepository implements ModelRepositoryInterface
             $this->throwModelNotFoundException();
         }
 
-        /** @var T $model */
+        /** @var TModel $model */
         return $model;
     }
 
     public function where($column, $operator = null, $value = null, string $boolean = 'and'): Collection
     {
-        /** @var Collection<int, T> $models */
+        /** @var Collection<int, TModel> $models */
         $models = $this->builder()->where($column, $operator, $value, $boolean)->get();
 
         return $models;
@@ -104,7 +105,7 @@ abstract class AbstractModelRepository implements ModelRepositoryInterface
 
     public function whereIn(string $column, array $values): Collection
     {
-        /** @var Collection<int, T> $models */
+        /** @var Collection<int, TModel> $models */
         $models = $this->builder()->whereIn($column, $values)->get();
 
         return $models;
@@ -113,11 +114,11 @@ abstract class AbstractModelRepository implements ModelRepositoryInterface
     /**
      * @param string  $column
      * @param mixed[] $values
-     * @return Collection<int, T>
+     * @return Collection<int, TModel>
      */
     public function whereNotIn(string $column, array $values): Collection
     {
-        /** @var Collection<int, T> $models */
+        /** @var Collection<int, TModel> $models */
         $models = $this->builder()->whereNotIn($column, $values)->get();
 
         return $models;
@@ -125,7 +126,7 @@ abstract class AbstractModelRepository implements ModelRepositoryInterface
 
     public function cursor(): LazyCollection
     {
-        /** @var LazyCollection<int, T> $models */
+        /** @var LazyCollection<int, TModel> $models */
         $models = $this->builder()->cursor();
 
         return $models;
@@ -133,7 +134,7 @@ abstract class AbstractModelRepository implements ModelRepositoryInterface
 
     public function all(string ...$column): Collection
     {
-        /** @var Collection<int, T> $models */
+        /** @var Collection<int, TModel> $models */
         $models = $this->builder()->get($this->parseColumns(...$column));
 
         return $models;
@@ -141,7 +142,7 @@ abstract class AbstractModelRepository implements ModelRepositoryInterface
 
     public function make(array $attributes)
     {
-        /** @var T $model */
+        /** @var TModel $model */
         $model = $this->builder()->make($attributes);
 
         return $model;
@@ -149,7 +150,7 @@ abstract class AbstractModelRepository implements ModelRepositoryInterface
 
     public function findOrMake($key, string ...$column)
     {
-        /** @var T $model */
+        /** @var TModel $model */
         $model = $this->builder()->findOrNew($key, $this->parseColumns(...$column));
 
         return $model;
@@ -157,7 +158,7 @@ abstract class AbstractModelRepository implements ModelRepositoryInterface
 
     public function firstWhereOrMake(array $attributes, array $values = [])
     {
-        /** @var T $model */
+        /** @var TModel $model */
         $model = $this->builder()->firstOrNew($attributes, $values);
 
         return $model;
@@ -165,7 +166,7 @@ abstract class AbstractModelRepository implements ModelRepositoryInterface
 
     public function create(array $attributes)
     {
-        /** @var T $model */
+        /** @var TModel $model */
         $model = $this->builder()->create($attributes);
 
         return $model;
@@ -173,7 +174,7 @@ abstract class AbstractModelRepository implements ModelRepositoryInterface
 
     public function firstWhereOrCreate(array $attributes, array $values = [])
     {
-        /** @var T $model */
+        /** @var TModel $model */
         $model = $this->builder()->firstOrCreate($attributes, $values);
 
         return $model;

--- a/tests/Integration/AbstractIntegrationTest.php
+++ b/tests/Integration/AbstractIntegrationTest.php
@@ -48,7 +48,7 @@ abstract class AbstractIntegrationTest extends TestCase
 
     protected function defineDatabaseMigrations(): void
     {
-        $this->loadMigrationsFrom(static::getLaravelPath('Database' . DIRECTORY_SEPARATOR . 'migrations'));
+        $this->loadMigrationsFrom(self::getLaravelPath('Database' . DIRECTORY_SEPARATOR . 'migrations'));
     }
 
     protected function resolveApplication()
@@ -65,7 +65,7 @@ abstract class AbstractIntegrationTest extends TestCase
 
     public static function applicationBasePath(): string
     {
-        return $_ENV['APP_BASE_PATH'] ?? static::getLaravelPath('');
+        return $_ENV['APP_BASE_PATH'] ?? self::getLaravelPath('');
     }
 
     protected static function getLaravelPath(string $path): string
@@ -85,7 +85,7 @@ abstract class AbstractIntegrationTest extends TestCase
 
     protected function getAppStubPath(string $file): string
     {
-        return static::getLaravelPath(
+        return self::getLaravelPath(
             'App' .
             DIRECTORY_SEPARATOR .
             $file,
@@ -94,7 +94,7 @@ abstract class AbstractIntegrationTest extends TestCase
 
     protected function getStubsPath(string $file): string
     {
-        return static::getLaravelPath(
+        return self::getLaravelPath(
             'stubs' .
             DIRECTORY_SEPARATOR .
             $file,

--- a/tests/Integration/Console/Commands/ModelRepositoryMakeCommandTest.php
+++ b/tests/Integration/Console/Commands/ModelRepositoryMakeCommandTest.php
@@ -38,10 +38,10 @@ class ModelRepositoryMakeCommandTest extends AbstractIntegrationTest
             ->expectsOutput('Repository created successfully.')
             ->execute();
 
-        static::assertFileExists($this->getRepositoryInterfacePath());
-        static::assertFileExists($this->getRepositoryPath());
+        self::assertFileExists($this->getRepositoryInterfacePath());
+        self::assertFileExists($this->getRepositoryPath());
 
-        static::assertSame(
+        self::assertSame(
             '<?php
 
 declare(strict_types=1);
@@ -59,7 +59,7 @@ interface ModelWithoutRepositoryRepositoryInterface extends ModelRepositoryInter
 }
 ', file_get_contents($this->getRepositoryInterfacePath()));
 
-        static::assertSame(
+        self::assertSame(
             '<?php
 
 declare(strict_types=1);
@@ -104,10 +104,10 @@ class ModelWithoutRepositoryRepository extends AbstractModelRepository implement
             ->expectsOutput('Repository created successfully.')
             ->execute();
 
-        static::assertFileExists($contractFile);
-        static::assertFileExists($repositoryFile);
+        self::assertFileExists($contractFile);
+        self::assertFileExists($repositoryFile);
 
-        static::assertSame(
+        self::assertSame(
             '<?php
 
 declare(strict_types=1);
@@ -125,7 +125,7 @@ interface Bar extends ModelRepositoryInterface
 }
 ', file_get_contents($contractFile));
 
-        static::assertSame(
+        self::assertSame(
             '<?php
 
 declare(strict_types=1);
@@ -204,11 +204,11 @@ class Foo extends AbstractModelRepository implements Bar
             ->expectsOutput('Repository created successfully.')
             ->execute();
 
-        static::assertFileExists($this->getRepositoryInterfacePath());
-        static::assertFileExists($this->getRepositoryPath());
+        self::assertFileExists($this->getRepositoryInterfacePath());
+        self::assertFileExists($this->getRepositoryPath());
 
-        static::assertSame('Foo', file_get_contents($this->getRepositoryInterfacePath()));
-        static::assertSame('Bar', file_get_contents($this->getRepositoryPath()));
+        self::assertSame('Foo', file_get_contents($this->getRepositoryInterfacePath()));
+        self::assertSame('Bar', file_get_contents($this->getRepositoryPath()));
 
         unlink($interfaceStub);
         unlink($repositoryStub);

--- a/tests/Integration/Console/Commands/StubsPublishCommandTest.php
+++ b/tests/Integration/Console/Commands/StubsPublishCommandTest.php
@@ -29,10 +29,10 @@ class StubsPublishCommandTest extends AbstractIntegrationTest
             ->expectsOutput('Repository stubs published successfully.')
             ->execute();
 
-        static::assertFileExists($this->getRepositoryInterfacePath());
-        static::assertFileExists($this->getRepositoryPath());
+        self::assertFileExists($this->getRepositoryInterfacePath());
+        self::assertFileExists($this->getRepositoryPath());
 
-        static::assertSame('<?php
+        self::assertSame('<?php
 
 declare(strict_types=1);
 
@@ -49,7 +49,7 @@ interface {{ class }} extends ModelRepositoryInterface
 }
 ', file_get_contents($this->getRepositoryInterfacePath()));
 
-        static::assertSame('<?php
+        self::assertSame('<?php
 
 declare(strict_types=1);
 

--- a/tests/Integration/Repositories/ModelRepositoryTest.php
+++ b/tests/Integration/Repositories/ModelRepositoryTest.php
@@ -112,11 +112,11 @@ class ModelRepositoryTest extends AbstractIntegrationTest
         /** @var ModelWithRepository $result */
         $result = $this->repository->find(23);
 
-        static::assertTrue($this->findModel->is($result));
+        self::assertTrue($this->findModel->is($result));
 
-        static::assertSame(23, $result->id);
-        static::assertSame('lorem', $result->foo);
-        static::assertSame('ipsum', $result->bar);
+        self::assertSame(23, $result->id);
+        self::assertSame('lorem', $result->foo);
+        self::assertSame('ipsum', $result->bar);
     }
 
     /**
@@ -128,9 +128,9 @@ class ModelRepositoryTest extends AbstractIntegrationTest
         /** @var ModelWithRepository $result */
         $result = $this->repository->find(23, 'id');
 
-        static::assertSame(23, $result->id);
-        static::assertNull($result->foo);
-        static::assertNull($result->bar);
+        self::assertSame(23, $result->id);
+        self::assertNull($result->foo);
+        self::assertNull($result->bar);
     }
 
     /**
@@ -142,9 +142,9 @@ class ModelRepositoryTest extends AbstractIntegrationTest
         /** @var ModelWithRepository $result */
         $result = $this->repository->find(23, 'id', 'foo');
 
-        static::assertSame(23, $result->id);
-        static::assertSame('lorem', $result->foo);
-        static::assertNull($result->bar);
+        self::assertSame(23, $result->id);
+        self::assertSame('lorem', $result->foo);
+        self::assertNull($result->bar);
     }
 
     /**
@@ -154,7 +154,7 @@ class ModelRepositoryTest extends AbstractIntegrationTest
     {
         $result = $this->repository->find(88);
 
-        static::assertNull($result);
+        self::assertNull($result);
     }
 
     /**
@@ -165,11 +165,11 @@ class ModelRepositoryTest extends AbstractIntegrationTest
         /** @var ModelWithRepository $result */
         $result = $this->repository->findOrFail(23);
 
-        static::assertTrue($this->findModel->is($result));
+        self::assertTrue($this->findModel->is($result));
 
-        static::assertSame(23, $result->id);
-        static::assertSame('lorem', $result->foo);
-        static::assertSame('ipsum', $result->bar);
+        self::assertSame(23, $result->id);
+        self::assertSame('lorem', $result->foo);
+        self::assertSame('ipsum', $result->bar);
     }
 
     /**
@@ -181,9 +181,9 @@ class ModelRepositoryTest extends AbstractIntegrationTest
         /** @var ModelWithRepository $result */
         $result = $this->repository->findOrFail(23, 'id');
 
-        static::assertSame(23, $result->id);
-        static::assertNull($result->foo);
-        static::assertNull($result->bar);
+        self::assertSame(23, $result->id);
+        self::assertNull($result->foo);
+        self::assertNull($result->bar);
     }
 
     /**
@@ -195,9 +195,9 @@ class ModelRepositoryTest extends AbstractIntegrationTest
         /** @var ModelWithRepository $result */
         $result = $this->repository->findOrFail(23, 'id', 'foo');
 
-        static::assertSame(23, $result->id);
-        static::assertSame('lorem', $result->foo);
-        static::assertNull($result->bar);
+        self::assertSame(23, $result->id);
+        self::assertSame('lorem', $result->foo);
+        self::assertNull($result->bar);
     }
 
     /**
@@ -205,8 +205,8 @@ class ModelRepositoryTest extends AbstractIntegrationTest
      */
     public function it_throws_an_exception_for_find_or_fail_when_a_model_cannot_be_found(): void
     {
-        static::expectException(ModelNotFoundException::class);
-        static::expectExceptionMessage('No query results for model [Wimski\ModelRepositories\Tests\Laravel\App\Models\ModelWithRepository]');
+        $this->expectException(ModelNotFoundException::class);
+        $this->expectExceptionMessage('No query results for model [Wimski\ModelRepositories\Tests\Laravel\App\Models\ModelWithRepository]');
 
         $this->repository->findOrFail(88);
     }
@@ -259,11 +259,11 @@ class ModelRepositoryTest extends AbstractIntegrationTest
         /** @var ModelWithRepository $result */
         $result = $this->repository->first();
 
-        static::assertTrue($this->firstModel->is($result));
+        self::assertTrue($this->firstModel->is($result));
 
-        static::assertSame(51, $result->id);
-        static::assertSame('amet', $result->foo);
-        static::assertSame('consectetur', $result->bar);
+        self::assertSame(51, $result->id);
+        self::assertSame('amet', $result->foo);
+        self::assertSame('consectetur', $result->bar);
     }
 
     /**
@@ -275,9 +275,9 @@ class ModelRepositoryTest extends AbstractIntegrationTest
         /** @var ModelWithRepository $result */
         $result = $this->repository->first('id');
 
-        static::assertSame(51, $result->id);
-        static::assertNull($result->foo);
-        static::assertNull($result->bar);
+        self::assertSame(51, $result->id);
+        self::assertNull($result->foo);
+        self::assertNull($result->bar);
     }
 
     /**
@@ -289,9 +289,9 @@ class ModelRepositoryTest extends AbstractIntegrationTest
         /** @var ModelWithRepository $result */
         $result = $this->repository->first('id', 'foo');
 
-        static::assertSame(51, $result->id);
-        static::assertSame('amet', $result->foo);
-        static::assertNull($result->bar);
+        self::assertSame(51, $result->id);
+        self::assertSame('amet', $result->foo);
+        self::assertNull($result->bar);
     }
 
     /**
@@ -303,7 +303,7 @@ class ModelRepositoryTest extends AbstractIntegrationTest
 
         $result = $this->repository->first();
 
-        static::assertNull($result);
+        self::assertNull($result);
     }
 
     /**
@@ -314,11 +314,11 @@ class ModelRepositoryTest extends AbstractIntegrationTest
         /** @var ModelWithRepository $result */
         $result = $this->repository->firstOrFail();
 
-        static::assertTrue($this->firstModel->is($result));
+        self::assertTrue($this->firstModel->is($result));
 
-        static::assertSame(51, $result->id);
-        static::assertSame('amet', $result->foo);
-        static::assertSame('consectetur', $result->bar);
+        self::assertSame(51, $result->id);
+        self::assertSame('amet', $result->foo);
+        self::assertSame('consectetur', $result->bar);
     }
 
     /**
@@ -330,9 +330,9 @@ class ModelRepositoryTest extends AbstractIntegrationTest
         /** @var ModelWithRepository $result */
         $result = $this->repository->firstOrFail('id');
 
-        static::assertSame(51, $result->id);
-        static::assertNull($result->foo);
-        static::assertNull($result->bar);
+        self::assertSame(51, $result->id);
+        self::assertNull($result->foo);
+        self::assertNull($result->bar);
     }
 
     /**
@@ -344,9 +344,9 @@ class ModelRepositoryTest extends AbstractIntegrationTest
         /** @var ModelWithRepository $result */
         $result = $this->repository->firstOrFail('id', 'foo');
 
-        static::assertSame(51, $result->id);
-        static::assertSame('amet', $result->foo);
-        static::assertNull($result->bar);
+        self::assertSame(51, $result->id);
+        self::assertSame('amet', $result->foo);
+        self::assertNull($result->bar);
     }
 
     /**
@@ -356,8 +356,8 @@ class ModelRepositoryTest extends AbstractIntegrationTest
     {
         ModelWithRepository::query()->delete();
 
-        static::expectException(ModelNotFoundException::class);
-        static::expectExceptionMessage('No query results for model [Wimski\ModelRepositories\Tests\Laravel\App\Models\ModelWithRepository]');
+        $this->expectException(ModelNotFoundException::class);
+        $this->expectExceptionMessage('No query results for model [Wimski\ModelRepositories\Tests\Laravel\App\Models\ModelWithRepository]');
 
         $this->repository->firstOrFail();
     }
@@ -369,14 +369,14 @@ class ModelRepositoryTest extends AbstractIntegrationTest
     {
         $result = $this->repository->firstWhere('foo', 'lorem');
 
-        static::assertTrue($this->findModel->is($result));
+        self::assertTrue($this->findModel->is($result));
 
         $result = $this->repository->firstWhere([
             'foo' => 'lorem',
             'bar' => 'ipsum',
         ]);
 
-        static::assertTrue($this->findModel->is($result));
+        self::assertTrue($this->findModel->is($result));
     }
 
     /**
@@ -386,7 +386,7 @@ class ModelRepositoryTest extends AbstractIntegrationTest
     {
         $result = $this->repository->whereIn('id', [23, 36]);
 
-        static::assertSame([
+        self::assertSame([
             23,
             36,
         ], $result->pluck('id')->values()->all());
@@ -399,7 +399,7 @@ class ModelRepositoryTest extends AbstractIntegrationTest
     {
         $result = $this->repository->whereNotIn('id', [23, 36]);
 
-        static::assertSame([
+        self::assertSame([
             51,
         ], $result->pluck('id')->values()->all());
     }
@@ -411,7 +411,7 @@ class ModelRepositoryTest extends AbstractIntegrationTest
     {
         $result = $this->repository->firstWhere('foo', 'something');
 
-        static::assertNull($result);
+        self::assertNull($result);
     }
 
     /**
@@ -421,14 +421,14 @@ class ModelRepositoryTest extends AbstractIntegrationTest
     {
         $result = $this->repository->firstWhereOrFail('foo', 'lorem');
 
-        static::assertTrue($this->findModel->is($result));
+        self::assertTrue($this->findModel->is($result));
 
         $result = $this->repository->firstWhereOrFail([
             'foo' => 'lorem',
             'bar' => 'ipsum',
         ]);
 
-        static::assertTrue($this->findModel->is($result));
+        self::assertTrue($this->findModel->is($result));
     }
 
     /**
@@ -436,8 +436,8 @@ class ModelRepositoryTest extends AbstractIntegrationTest
      */
     public function it_throws_an_exception_for_first_where_or_fail_when_a_model_cannot_be_found(): void
     {
-        static::expectException(ModelNotFoundException::class);
-        static::expectExceptionMessage('No query results for model [Wimski\ModelRepositories\Tests\Laravel\App\Models\ModelWithRepository]');
+        $this->expectException(ModelNotFoundException::class);
+        $this->expectExceptionMessage('No query results for model [Wimski\ModelRepositories\Tests\Laravel\App\Models\ModelWithRepository]');
 
         $this->repository->firstWhereOrFail('foo', 'something');
     }
@@ -449,7 +449,7 @@ class ModelRepositoryTest extends AbstractIntegrationTest
     {
         $result = $this->repository->where('foo', 'lorem');
 
-        static::assertSame([
+        self::assertSame([
             23,
             36,
         ], $result->pluck('id')->values()->all());
@@ -458,7 +458,7 @@ class ModelRepositoryTest extends AbstractIntegrationTest
             'foo' => 'lorem',
         ]);
 
-        static::assertSame([
+        self::assertSame([
             23,
             36,
         ], $result->pluck('id')->values()->all());
@@ -471,19 +471,19 @@ class ModelRepositoryTest extends AbstractIntegrationTest
     {
         $result = $this->repository->cursor();
 
-        static::assertCount(3, $result);
+        self::assertCount(3, $result);
 
         $result1 = $result->get(0);
-        static::assertInstanceOf(ModelWithRepository::class, $result1);
-        static::assertSame(51, $result1->getKey());
+        self::assertInstanceOf(ModelWithRepository::class, $result1);
+        self::assertSame(51, $result1->getKey());
 
         $result2 = $result->get(1);
-        static::assertInstanceOf(ModelWithRepository::class, $result2);
-        static::assertSame(23, $result2->getKey());
+        self::assertInstanceOf(ModelWithRepository::class, $result2);
+        self::assertSame(23, $result2->getKey());
 
         $result3 = $result->get(2);
-        static::assertInstanceOf(ModelWithRepository::class, $result3);
-        static::assertSame(36, $result3->getKey());
+        self::assertInstanceOf(ModelWithRepository::class, $result3);
+        self::assertSame(36, $result3->getKey());
     }
 
     /**
@@ -534,9 +534,9 @@ class ModelRepositoryTest extends AbstractIntegrationTest
         /** @var ModelWithRepository $result */
         $result = $this->repository->make(['foo' => 'bar']);
 
-        static::assertFalse($result->exists);
-        static::assertSame('bar', $result->foo);
-        static::assertNull($result->bar);
+        self::assertFalse($result->exists);
+        self::assertSame('bar', $result->foo);
+        self::assertNull($result->bar);
     }
 
     /**
@@ -547,11 +547,11 @@ class ModelRepositoryTest extends AbstractIntegrationTest
         /** @var ModelWithRepository $result */
         $result = $this->repository->findOrMake(23);
 
-        static::assertTrue($this->findModel->is($result));
+        self::assertTrue($this->findModel->is($result));
 
-        static::assertSame(23, $result->id);
-        static::assertSame('lorem', $result->foo);
-        static::assertSame('ipsum', $result->bar);
+        self::assertSame(23, $result->id);
+        self::assertSame('lorem', $result->foo);
+        self::assertSame('ipsum', $result->bar);
     }
 
     /**
@@ -563,9 +563,9 @@ class ModelRepositoryTest extends AbstractIntegrationTest
         /** @var ModelWithRepository $result */
         $result = $this->repository->findOrMake(23, 'id');
 
-        static::assertSame(23, $result->id);
-        static::assertNull($result->foo);
-        static::assertNull($result->bar);
+        self::assertSame(23, $result->id);
+        self::assertNull($result->foo);
+        self::assertNull($result->bar);
     }
 
     /**
@@ -577,9 +577,9 @@ class ModelRepositoryTest extends AbstractIntegrationTest
         /** @var ModelWithRepository $result */
         $result = $this->repository->findOrMake(23, 'id', 'foo');
 
-        static::assertSame(23, $result->id);
-        static::assertSame('lorem', $result->foo);
-        static::assertNull($result->bar);
+        self::assertSame(23, $result->id);
+        self::assertSame('lorem', $result->foo);
+        self::assertNull($result->bar);
     }
 
     /**
@@ -590,9 +590,9 @@ class ModelRepositoryTest extends AbstractIntegrationTest
         /** @var ModelWithRepository $result */
         $result = $this->repository->findOrMake(88);
 
-        static::assertFalse($result->exists);
-        static::assertNull($result->foo);
-        static::assertNull($result->bar);
+        self::assertFalse($result->exists);
+        self::assertNull($result->foo);
+        self::assertNull($result->bar);
     }
 
     /**
@@ -605,7 +605,7 @@ class ModelRepositoryTest extends AbstractIntegrationTest
             'bar' => 'ipsum',
         ]);
 
-        static::assertTrue($this->findModel->is($result));
+        self::assertTrue($this->findModel->is($result));
     }
 
     /**
@@ -619,9 +619,9 @@ class ModelRepositoryTest extends AbstractIntegrationTest
             ['bar' => 'stuff'],
         );
 
-        static::assertFalse($result->exists);
-        static::assertSame('something', $result->foo);
-        static::assertSame('stuff', $result->bar);
+        self::assertFalse($result->exists);
+        self::assertSame('something', $result->foo);
+        self::assertSame('stuff', $result->bar);
     }
 
     /**
@@ -635,9 +635,9 @@ class ModelRepositoryTest extends AbstractIntegrationTest
             'bar' => 'foo',
         ]);
 
-        static::assertTrue($result->exists);
-        static::assertSame('bar', $result->foo);
-        static::assertSame('foo', $result->bar);
+        self::assertTrue($result->exists);
+        self::assertSame('bar', $result->foo);
+        self::assertSame('foo', $result->bar);
 
         $this->assertDatabaseCount('model_with_repositories', 4);
     }
@@ -652,7 +652,7 @@ class ModelRepositoryTest extends AbstractIntegrationTest
             'bar' => 'ipsum',
         ]);
 
-        static::assertTrue($this->findModel->is($result));
+        self::assertTrue($this->findModel->is($result));
     }
 
     /**
@@ -666,9 +666,9 @@ class ModelRepositoryTest extends AbstractIntegrationTest
             ['bar' => 'stuff'],
         );
 
-        static::assertTrue($result->exists);
-        static::assertSame('something', $result->foo);
-        static::assertSame('stuff', $result->bar);
+        self::assertTrue($result->exists);
+        self::assertSame('something', $result->foo);
+        self::assertSame('stuff', $result->bar);
 
         $this->assertDatabaseCount('model_with_repositories', 4);
     }
@@ -679,13 +679,13 @@ class ModelRepositoryTest extends AbstractIntegrationTest
      */
     protected function assertSameModels(Collection $expected, Collection $actual): void
     {
-        static::assertSameSize($expected, $actual);
+        self::assertSameSize($expected, $actual);
 
         foreach ($expected as $index => $expectedModel) {
             /** @var Model $actualModel */
             $actualModel = $actual->get($index);
 
-            static::assertTrue($actualModel->is($expectedModel));
+            self::assertTrue($actualModel->is($expectedModel));
         }
     }
 
@@ -695,7 +695,7 @@ class ModelRepositoryTest extends AbstractIntegrationTest
      */
     protected function assertModelsHaveColumn(Collection $models, string $column): void
     {
-        static::assertEmpty(
+        self::assertEmpty(
             $models->pluck($column)->filter(function ($value): bool {
                 return $value === null;
             })->values()->all(),
@@ -709,7 +709,7 @@ class ModelRepositoryTest extends AbstractIntegrationTest
      */
     protected function assertModelsDoNotHaveColumn(Collection $models, string $column): void
     {
-        static::assertEmpty(
+        self::assertEmpty(
             $models->pluck($column)->filter(function ($value): bool {
                 return $value !== null;
             })->values()->all(),

--- a/tests/Laravel/App/Models/ModelWithRepository.php
+++ b/tests/Laravel/App/Models/ModelWithRepository.php
@@ -7,13 +7,14 @@ namespace Wimski\ModelRepositories\Tests\Laravel\App\Models;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Wimski\ModelRepositories\Tests\Laravel\App\Scopes\GlobalScope;
 use Wimski\ModelRepositories\Tests\Laravel\Database\Factories\ModelWithRepositoryFactory;
 
 /**
  * @property int $id
  * @property string|null $foo
  * @property string|null $bar
- * @method static \Wimski\ModelRepositories\Tests\Laravel\Database\Factories\ModelWithRepositoryFactory factory(...$parameters)
+ * @method static ModelWithRepositoryFactory factory(...$parameters)
  */
 class ModelWithRepository extends Model
 {
@@ -26,6 +27,11 @@ class ModelWithRepository extends Model
         'foo',
         'bar',
     ];
+
+    protected static function booted(): void
+    {
+        self::addGlobalScope(new GlobalScope());
+    }
 
     /**
      * @return Factory<ModelWithRepository>

--- a/tests/Laravel/App/Scopes/GlobalScope.php
+++ b/tests/Laravel/App/Scopes/GlobalScope.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Wimski\ModelRepositories\Tests\Laravel\App\Scopes;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Scope;
+
+class GlobalScope implements Scope
+{
+    /**
+     * @template TModel of Model
+     * @param  Builder<TModel> $builder
+     * @param  TModel          $model
+     * @return void
+     */
+    public function apply(Builder $builder, Model $model): void
+    {
+        $builder
+            ->orderBy('bar')
+            ->orderBy('foo')
+            ->orderBy('id');
+    }
+}

--- a/tests/Unit/DataObjects/NamespaceDataObjectTest.php
+++ b/tests/Unit/DataObjects/NamespaceDataObjectTest.php
@@ -27,7 +27,7 @@ class NamespaceDataObjectTest extends AbstractUnitTest
      */
     public function it_returns_the_model_namespace(): void
     {
-        static::assertSame('models-namespace', $this->dataObject->getModelsNamespace());
+        self::assertSame('models-namespace', $this->dataObject->getModelsNamespace());
     }
 
     /**
@@ -35,7 +35,7 @@ class NamespaceDataObjectTest extends AbstractUnitTest
      */
     public function it_returns_the_contract_namespace(): void
     {
-        static::assertSame('contracts-namespace', $this->dataObject->getContractsNamespace());
+        self::assertSame('contracts-namespace', $this->dataObject->getContractsNamespace());
     }
 
     /**
@@ -43,6 +43,6 @@ class NamespaceDataObjectTest extends AbstractUnitTest
      */
     public function it_returns_the_repository_namespace(): void
     {
-        static::assertSame('repositories-namespace', $this->dataObject->getRepositoriesNamespace());
+        self::assertSame('repositories-namespace', $this->dataObject->getRepositoriesNamespace());
     }
 }

--- a/tests/Unit/Resolvers/NamespaceResolverTest.php
+++ b/tests/Unit/Resolvers/NamespaceResolverTest.php
@@ -48,7 +48,7 @@ class NamespaceResolverTest extends AbstractUnitTest
 
         $namespaces = $this->resolver->resolve('App\\Models\\Foo\\Bar');
 
-        static::assertSame('\\App\\Models', $namespaces->getModelsNamespace());
+        self::assertSame('\\App\\Models', $namespaces->getModelsNamespace());
     }
 
     /**
@@ -56,8 +56,8 @@ class NamespaceResolverTest extends AbstractUnitTest
      */
     public function it_throws_an_error_if_no_namespace_configuration_could_be_found_for_a_model_class(): void
     {
-        static::expectException(Exception::class);
-        static::expectExceptionMessage('No namespace found for Foo\\Bar');
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('No namespace found for Foo\\Bar');
 
         $this->config
             ->shouldReceive('get')

--- a/tests/Unit/Resolvers/StubsPathResolverTest.php
+++ b/tests/Unit/Resolvers/StubsPathResolverTest.php
@@ -35,7 +35,7 @@ class StubsPathResolverTest extends AbstractUnitTest
     {
         $path = $this->resolver->resolvePackagePath('stub-file');
 
-        static::assertSame(
+        self::assertSame(
             dirname(__DIR__, 3) .
             DIRECTORY_SEPARATOR .
             'stubs' .
@@ -64,6 +64,6 @@ class StubsPathResolverTest extends AbstractUnitTest
 
         $path = $this->resolver->resolveAppPath('stub-file');
 
-        static::assertSame('app-path', $path);
+        self::assertSame('app-path', $path);
     }
 }


### PR DESCRIPTION
#### `ModelRepositoryInterface::builder()`
Changed the return type from `Builder<TModel>` to `Builder<TModel>|TModel` to support chaining scopes, which are only known to the model and not the builder.

I consider this a breaking change, therefore the major version increase.

#### `AbstractModelRepository::builder()`
To facilitate the changed return type, the concrete builder method now does what the Laravel model does itself within `newQuery`:
```php
// Illuminate\Database\Eloquent\Model
    public function newQuery()
    {
        return $this->registerGlobalScopes($this->newQueryWithoutScopes());
    }
```
I've opted to make the registering of global scopes optional as an extra feature.
```php
// Wimski\ModelRepositories\Repositories\AbstractModelRepository
    public function builder(bool $withGlobalScopes = true)
    {
        /** @var Builder<TModel> $builder */
        $builder = $this->model->newQueryWithoutScopes();

        if ($withGlobalScopes) {
            $this->model->registerGlobalScopes($builder);
        }

        /** @var Builder<TModel>|TModel $builder */
        return $builder;
    }
```